### PR TITLE
add encoder for Int type

### DIFF
--- a/int.go
+++ b/int.go
@@ -26,7 +26,7 @@ func NewInt(i int64, valid bool) Int {
 }
 
 // Encoder fulfills the requirements for encoding a null.Int for schema.RegisterEncoder
-func Encoder(val reflect.Value) string {
+func (Int) Encoder(val reflect.Value) string {
 	convVal := val.Interface().(Int)
 	return strconv.Itoa(int(convVal.ValueOrZero()))
 }

--- a/int.go
+++ b/int.go
@@ -25,9 +25,12 @@ func NewInt(i int64, valid bool) Int {
 	}
 }
 
-// Encoder fulfills the requirements for encoding a null.Int for schema.RegisterEncoder
-func (Int) Encoder(val reflect.Value) string {
+// EncoderInt fulfills the requirements for encoding a null.Int for schema.RegisterEncoder
+func EncoderInt(val reflect.Value) string {
 	convVal := val.Interface().(Int)
+	if convVal.ValueOrZero() == 0 {
+		return "null"
+	}
 	return strconv.Itoa(int(convVal.ValueOrZero()))
 }
 

--- a/int.go
+++ b/int.go
@@ -25,6 +25,12 @@ func NewInt(i int64, valid bool) Int {
 	}
 }
 
+// Encoder fulfills the requirements for encoding a null.Int for schema.RegisterEncoder
+func Encoder(val reflect.Value) string {
+	convVal := val.Interface().(Int)
+	return strconv.Itoa(int(convVal.ValueOrZero()))
+}
+
 // IntFrom creates a new Int that will always be valid.
 func IntFrom(i int64) Int {
 	return NewInt(i, true)


### PR DESCRIPTION
Adds an encoder to Int for use with https://github.com/gorilla/schema/blob/master/encoder.go#L33

This is intended to reduce the encoding burden for microservice communication